### PR TITLE
Add array of observers to guarantee order

### DIFF
--- a/src/command/stream-event-appeared/index.ts
+++ b/src/command/stream-event-appeared/index.ts
@@ -4,8 +4,8 @@ import { eventstore } from "esproto";
 export const CODE = 0xC2;
 export type CODE = typeof CODE;
 export type Params = eventstore.proto.StreamEventAppeared$Properties;
-export interface Observer {
-  (command: Command): void;
-}
+export type Observer = (command: Command) => void;
+export type OrderedObserver = Array<Observer>;
+export type SubscriptionObserver = Observer | OrderedObserver;
 export interface Command extends C<CODE, eventstore.proto.StreamEventAppeared> { }
 export const Message = eventstore.proto.StreamEventAppeared;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,24 +49,26 @@ process.nextTick(async () => {
   const result1 = await connection.subscribeToStream({
     eventStreamId: "$ce-user",
     resolveLinkTos: true
-  }, (command) => {
-    console.log("handler 1", command.key);
+  }, [
+      (command) => {
+        console.log("handler 1", command.key);
+      }, (command) => {
+        console.log("handler 2", command.key);
+      }, (command) => {
+        console.log("handler 3", command.key);
+      }, (command) => {
+        console.log("handler 4", command.key);
+      }
+    ]);
+  connection.addSubscriptionObserver(result1.key, (command) => {
+    console.log("handler 5", command.key);
   });
   connection.addSubscriptionObserver(result1.key, (command) => {
-    console.log("handler 2", command.key);
+    console.log("handler 6", command.key);
   });
-  console.log(result1);
-  const result2 = await connection.subscribeToStream({
-    eventStreamId: "$ce-user",
-    resolveLinkTos: true
-  }, (command) => {
-    console.log("handler 3", command.key);
+  connection.addSubscriptionObserver(result1.key, (command) => {
+    console.log("handler 7", command.key);
   });
-  connection.addSubscriptionObserver(result2.key, (command) => {
-    console.log("handler 4", command.key);
-  });
-  console.log(result2);
-  console.log(connection._subscriptions);
 });
 
 let cursor = 0;
@@ -78,7 +80,7 @@ setInterval(() => {
     expectedVersion: ExpectedVersion.Any,
     requireMaster: false
   });
-}, 5000);
+}, 500);
 
 setInterval(() => {
   console.log("Creating something else...");
@@ -88,4 +90,4 @@ setInterval(() => {
     expectedVersion: ExpectedVersion.Any,
     requireMaster: false
   });
-}, 5000);
+}, 500);


### PR DESCRIPTION
- Subscribing to a stream can now take an array of observers.  These observers are guaranteed to be called in the order they are defined in the array.

- The overall order of the set of subscribers amongst all subscribers to the stream is not guaranteed.  i.e. if A is one subscriber and B is a set of subscribers, A may receive and process an incoming event before or after B.