### PR TITLE
Add subscribe to all command

### DIFF
--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -89,7 +89,7 @@ export class Connection {
   public async startTransaction(params: Commands.TransactionStart.Params) {
     const command = Commands.getCommand(Commands.TransactionStart.CODE, params);
     const result = await this._dispatcher.dispatch(command);
-    if (result.message.result === 0) this._transactionManager.addTransaction(new Transaction.Transaction(result.message.transactionId));
+    if (result.id === Commands.TransactionStartCompleted.CODE && result.message.result === 0) this._transactionManager.addTransaction(new Transaction.Transaction(result.message.transactionId));
     return result;
   }
 
@@ -105,7 +105,7 @@ export class Connection {
     if (this._transactionManager.canCommitTransaction(params.transactionId)) {
       const command = Commands.getCommand(Commands.TransactionCommit.CODE, params);
       const result = await this._dispatcher.dispatch(command);
-      if (result.message.result === 0) this._transactionManager.commitTransaction(params.transactionId);
+      if (result.id === Commands.TransactionCommitCompleted.CODE && result.message.result === 0) this._transactionManager.commitTransaction(params.transactionId);
       return result;
     }
     return false;
@@ -123,6 +123,10 @@ export class Connection {
       this._subscriptionManager.addSubscription(params.eventStreamId, command.key, observer);
       await this._dispatcher.dispatch(command);
     }
+  }
+
+  public async subscribeToAll(observer?: Subscription.Observer, resolveLinkTos = true) {
+    this.subscribeToStream({ eventStreamId: "$streams", resolveLinkTos }, observer);
   }
 
   public async unsubscribeFromStream(streamId: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,16 @@ const eventData = data.map((e) => ({
 const connection = new Connection({ host: "192.168.99.100", credentials: { username: "admin", password: "changeit" } });
 process.nextTick(async () => {
 
-  const result = await connection.authenticate();
-  console.log(result);
+  await connection.subscribeToAll(new Rx.Subscriber((command) => {
+    console.log("handler 1", command);
+  }));
+
+  await connection.subscribeToStream({ eventStreamId: "$ce-user", resolveLinkTos: true }, new Rx.Subscriber((command) => {
+    console.log("handler 2", command);
+  }));
+
+  // const result = await connection.authenticate();
+  // console.log(result);
 
   // const result = await connection.readEvent({ eventStreamId: "$ce-user", eventNumber: 0, resolveLinkTos: true, requireMaster: false });
   // console.log(result);
@@ -100,16 +108,16 @@ process.nextTick(async () => {
 
 });
 
-// let cursor = 0;
-// setInterval(() => {
-//   console.log("Creating user...");
-//   connection.writeEvents({
-//     eventStreamId: `user-${v4()}`,
-//     events: [ eventData[ cursor++ ] ],
-//     expectedVersion: ExpectedVersion.Any,
-//     requireMaster: false
-//   });
-// }, 1000);
+let cursor = 0;
+setInterval(() => {
+  console.log("Creating user...");
+  connection.writeEvents({
+    eventStreamId: `user-${v4()}`,
+    events: [ eventData[ cursor++ ] ],
+    expectedVersion: ExpectedVersion.Any,
+    requireMaster: false
+  });
+}, 1000);
 
 // setTimeout(() => {
 //   console.log("dropping");


### PR DESCRIPTION
Note this subscribes to all streams, not all events in the whole event store.  This is because subscribing to $all is explicitly prohibited.  A projection could be set up to aggregate any set of system events that are needed.